### PR TITLE
added dependency on repoze.xmliter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(name='collective.newrelic',
       install_requires=[
           'setuptools',
           # -*- Extra requirements: -*-
-          'newrelic'
+          'newrelic',
+          'repoze.xmliter'
       ],
       tests_require=tests_require,
       extras_require=dict(tests=tests_require),


### PR DESCRIPTION
When I installed the current version of collective.newrelic, configured it according to the documentation and started my zeoclients, they kept rebooting on their own. In the logs I found the following (surrounded by a huge stacktrace of the startup process of a zeoclient):

```
File "/opt/buildouts/xxx/src/collective.newrelic/collective/newrelic/transforms/outputfilter.py", line 16, in <module>

    from repoze.xmliter.utils import getHTMLSerializer
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/opt/buildouts/xxx/parts/zeoclient/etc/site.zcml", line 16.2-16.23

    ZopeXMLConfigurationError: File "/opt/buildouts/.buildout/eggs/Products.CMFPlone/configure.zcml", line 99.4-103.10
    ZopeXMLConfigurationError: File "/opt/buildouts/xxx/src/collective.newrelic/collective/newrelic/configure.zcml", line 10.4-10.37
    ZopeXMLConfigurationError: File "/opt/buildouts/xxx/src/collective.newrelic/collective/newrelic/transforms/configure.zcml", line 10.4-15.10
    ImportError: No module named repoze.xmliter.utils
```

The culprit is line 16 of collective/newrelic/transforms/outputfilter.py which seems to be a dependency on https://pypi.python.org/pypi/repoze.xmliter : 

```
from repoze.xmliter.utils import getHTMLSerializer
```

Adding this package as a dependency to setup.py fixes this problem, which is what I did in this fork. 
(As this is my first fork and contribution to a github.com project, if I did something wrong please bear with me. I just followed the github.com tutorials)
